### PR TITLE
Handle trailing slash in mount parameter for secret related tools

### DIFF
--- a/pkg/hashicorp/vault/delete_secret.go
+++ b/pkg/hashicorp/vault/delete_secret.go
@@ -18,7 +18,7 @@ func DeleteSecret(logger *log.Logger) server.ServerTool {
 	return server.ServerTool{
 		Tool: mcp.NewTool("delete_secret",
 			mcp.WithDescription("Delete a secret from a KV mount in Vault using the specified path and mount."),
-			mcp.WithString("mount", mcp.Required(), mcp.Description("The mount path of the secret engine. For example, if you want to delete to 'secrets/application/credentials', this should be 'secrets'.")),
+			mcp.WithString("mount", mcp.Required(), mcp.Description("The mount path of the secret engine. For example, if you want to delete to 'secrets/application/credentials', this should be 'secrets' without the trailing slash.")),
 			mcp.WithString("path", mcp.Required(), mcp.Description("The full path to delete the secret to without the mount prefix. For example, if you want to delete to 'secrets/application/credentials', this should be 'application/credentials'.")),
 			mcp.WithString("key", mcp.DefaultString(""), mcp.Description("A optional key in the secret to delete. If not specified, all keys in the the secret will be deleted.")),
 		),
@@ -32,28 +32,25 @@ func deleteSecretHandler(ctx context.Context, req mcp.CallToolRequest, logger *l
 	logger.Debug("Handling delete_secret request")
 
 	// Extract parameters
-	var mount, path, key string
+	args, ok := req.Params.Arguments.(map[string]interface{})
+	if !ok {
+		return mcp.NewToolResultError("Missing or invalid arguments format"), nil
+	}
 
-	if req.Params.Arguments != nil {
-		if args, ok := req.Params.Arguments.(map[string]interface{}); ok {
-			if mount, ok = args["mount"].(string); !ok || mount == "" {
-				return mcp.NewToolResultError("Missing or invalid 'mount' parameter"), nil
-			}
+	mount, err := extractMountPath(args)
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
 
-			if path, ok = args["path"].(string); !ok || path == "" {
-				return mcp.NewToolResultError("Missing or invalid 'path' parameter"), nil
-			}
+	path, ok := args["path"].(string)
+	if !ok || path == "" {
+		return mcp.NewToolResultError("Missing or invalid 'path' parameter"), nil
+	}
 
-			// Can be empty to delete the entire secret
-			if key, ok = args["key"].(string); !ok {
-				return mcp.NewToolResultError("Missing or invalid 'key' parameter"), nil
-			}
-
-		} else {
-			return mcp.NewToolResultError("Invalid arguments format"), nil
-		}
-	} else {
-		return mcp.NewToolResultError("Missing arguments"), nil
+	// Can be empty to delete the entire secret
+	key, ok := args["key"].(string)
+	if !ok {
+		return mcp.NewToolResultError("Missing or invalid 'key' parameter"), nil
 	}
 
 	logger.WithFields(log.Fields{
@@ -75,7 +72,7 @@ func deleteSecretHandler(ctx context.Context, req mcp.CallToolRequest, logger *l
 	}
 
 	// Default to a v1 KV path
-	fullPath := fmt.Sprintf("%s/%s", strings.TrimSuffix(mount, "/"), strings.TrimPrefix(path, "/"))
+	fullPath := fmt.Sprintf("%s/%s", mount, strings.TrimPrefix(path, "/"))
 
 	isV2 := false
 
@@ -85,7 +82,7 @@ func deleteSecretHandler(ctx context.Context, req mcp.CallToolRequest, logger *l
 		if m.Options["version"] == "2" {
 			isV2 = true
 			// Construct the full path for reading (KV v2 format)
-			fullPath = fmt.Sprintf("%s/data/%s", strings.TrimSuffix(mount, "/"), strings.TrimPrefix(path, "/"))
+			fullPath = fmt.Sprintf("%s/data/%s", mount, strings.TrimPrefix(path, "/"))
 		}
 	} else {
 		return mcp.NewToolResultError(fmt.Sprintf("mount path '%s' does not exist. Use 'create_mount' with the type kv2 to create the mount.", mount)), nil

--- a/pkg/hashicorp/vault/list_secrets.go
+++ b/pkg/hashicorp/vault/list_secrets.go
@@ -7,10 +7,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
+
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
 	log "github.com/sirupsen/logrus"
-	"strings"
 )
 
 // ListSecrets creates a tool for listing secrets in a Vault KV mount
@@ -18,7 +19,7 @@ func ListSecrets(logger *log.Logger) server.ServerTool {
 	return server.ServerTool{
 		Tool: mcp.NewTool("list_secrets",
 			mcp.WithDescription("List secrets in a KV mount under a specific path in Vault"),
-			mcp.WithString("mount", mcp.Required(), mcp.Description("The mount path of the secret engine. For example, if you want to list 'secrets/application/credentials', this should be 'secrets'.")),
+			mcp.WithString("mount", mcp.Required(), mcp.Description("The mount path of the secret engine. For example, if you want to list 'secrets/application/credentials', this should be 'secrets' without the trailing slash.")),
 			mcp.WithString("path", mcp.DefaultString(""), mcp.Description("The full path to list the secrets to without the mount prefix. For example, if you want to list from 'secrets/application/credentials', this should be 'application/credentials'.")),
 		),
 		Handler: func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
@@ -31,23 +32,19 @@ func listSecretsHandler(ctx context.Context, req mcp.CallToolRequest, logger *lo
 	logger.Debug("Handling list_secrets request")
 
 	// Extract parameters
-	var mount, path string
+	args, ok := req.Params.Arguments.(map[string]interface{})
+	if !ok {
+		return mcp.NewToolResultError("Missing or invalid arguments format"), nil
+	}
 
-	if req.Params.Arguments != nil {
-		if args, ok := req.Params.Arguments.(map[string]interface{}); ok {
-			if mount, ok = args["mount"].(string); !ok || mount == "" {
-				return mcp.NewToolResultError("Missing or invalid 'mount' parameter"), nil
-			}
+	mount, err := extractMountPath(args)
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
 
-			path, _ = args["path"].(string)
-			if path == "" {
-				path = ""
-			}
-		} else {
-			return mcp.NewToolResultError("Invalid arguments format"), nil
-		}
-	} else {
-		return mcp.NewToolResultError("Missing arguments"), nil
+	path, _ := args["path"].(string)
+	if path == "" {
+		path = ""
 	}
 
 	logger.WithFields(log.Fields{
@@ -75,9 +72,9 @@ func listSecretsHandler(ctx context.Context, req mcp.CallToolRequest, logger *lo
 		// is it a KV v2 mount?
 		if m.Options["version"] == "2" {
 			if path == "" {
-				fullPath = fmt.Sprintf("%s/metadata/", strings.TrimSuffix(mount, "/"))
+				fullPath = fmt.Sprintf("%s/metadata/", mount)
 			} else {
-				fullPath = fmt.Sprintf("%s/metadata/%s", strings.TrimSuffix(mount, "/"), strings.TrimPrefix(path, "/"))
+				fullPath = fmt.Sprintf("%s/metadata/%s", mount, strings.TrimPrefix(path, "/"))
 			}
 		}
 	} else {

--- a/pkg/hashicorp/vault/read_secret.go
+++ b/pkg/hashicorp/vault/read_secret.go
@@ -19,7 +19,7 @@ func ReadSecret(logger *log.Logger) server.ServerTool {
 	return server.ServerTool{
 		Tool: mcp.NewTool("read_secret",
 			mcp.WithDescription("Read a secret from a KV mount in Vault"),
-			mcp.WithString("mount", mcp.Required(), mcp.Description("The mount path of the secret engine. For example, if you want to read from 'secrets/application/credentials', this should be 'secrets'.")),
+			mcp.WithString("mount", mcp.Required(), mcp.Description("The mount path of the secret engine. For example, if you want to read from 'secrets/application/credentials', this should be 'secrets' without the trailing slash.")),
 			mcp.WithString("path", mcp.Required(), mcp.Description("The full path to read the secret to without the mount prefix. For example, if you want to read from 'secrets/application/credentials', this should be 'application/credentials'.")),
 		),
 		Handler: func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
@@ -32,22 +32,19 @@ func readSecretHandler(ctx context.Context, req mcp.CallToolRequest, logger *log
 	logger.Debug("Handling read_secret request")
 
 	// Extract parameters
-	var mount, path string
+	args, ok := req.Params.Arguments.(map[string]interface{})
+	if !ok {
+		return mcp.NewToolResultError("Missing or invalid arguments format"), nil
+	}
 
-	if req.Params.Arguments != nil {
-		if args, ok := req.Params.Arguments.(map[string]interface{}); ok {
-			if mount, ok = args["mount"].(string); !ok || mount == "" {
-				return mcp.NewToolResultError("Missing or invalid 'mount' parameter"), nil
-			}
+	mount, err := extractMountPath(args)
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
 
-			if path, ok = args["path"].(string); !ok || path == "" {
-				return mcp.NewToolResultError("Missing or invalid 'path' parameter"), nil
-			}
-		} else {
-			return mcp.NewToolResultError("Invalid arguments format"), nil
-		}
-	} else {
-		return mcp.NewToolResultError("Missing arguments"), nil
+	path, ok := args["path"].(string)
+	if !ok || path == "" {
+		return mcp.NewToolResultError("Missing or invalid 'path' parameter"), nil
 	}
 
 	logger.WithFields(log.Fields{
@@ -68,7 +65,7 @@ func readSecretHandler(ctx context.Context, req mcp.CallToolRequest, logger *log
 	}
 
 	// Default to a v1 KV path
-	fullPath := fmt.Sprintf("%s/%s", strings.TrimSuffix(mount, "/"), strings.TrimPrefix(path, "/"))
+	fullPath := fmt.Sprintf("%s/%s", mount, strings.TrimPrefix(path, "/"))
 
 	isV2 := false
 
@@ -78,7 +75,7 @@ func readSecretHandler(ctx context.Context, req mcp.CallToolRequest, logger *log
 		if m.Options["version"] == "2" {
 			isV2 = true
 			// Construct the full path for reading (KV v2 format)
-			fullPath = fmt.Sprintf("%s/data/%s", strings.TrimSuffix(mount, "/"), strings.TrimPrefix(path, "/"))
+			fullPath = fmt.Sprintf("%s/data/%s", mount, strings.TrimPrefix(path, "/"))
 		}
 	} else {
 		return mcp.NewToolResultError(fmt.Sprintf("mount path '%s' does not exist. Use 'create_mount' with the type kv2 to create the mount.", mount)), nil

--- a/pkg/hashicorp/vault/tool_params.go
+++ b/pkg/hashicorp/vault/tool_params.go
@@ -1,0 +1,18 @@
+package vault
+
+import (
+	"fmt"
+	"strings"
+)
+
+func extractMountPath(args map[string]any) (string, error) {
+	mount, ok := args["mount"].(string)
+	if !ok || mount == "" || mount == "/" {
+		return "", fmt.Errorf("missing or invalid 'mount' parameter")
+	}
+
+	// Remove trailing slash if present
+	mount = strings.TrimSuffix(mount, "/")
+
+	return mount, nil
+}

--- a/pkg/hashicorp/vault/write_secret.go
+++ b/pkg/hashicorp/vault/write_secret.go
@@ -18,7 +18,7 @@ func WriteSecret(logger *log.Logger) server.ServerTool {
 	return server.ServerTool{
 		Tool: mcp.NewTool("write_secret",
 			mcp.WithDescription("Writes a secret value to a KV store in Vault using the specified path and mount. Supports both KV v1 and v2 mounts. If a KV v2 mount is detected, the currently stored version of the secret will be returned."),
-			mcp.WithString("mount", mcp.Required(), mcp.Description("The mount path of the secret engine. For example, if you want to write to 'secrets/application/credentials', this should be 'secrets'.")),
+			mcp.WithString("mount", mcp.Required(), mcp.Description("The mount path of the secret engine. For example, if you want to write to 'secrets/application/credentials', this should be 'secrets' without the trailing slash.")),
 			mcp.WithString("path", mcp.Required(), mcp.Description("The full path to write the secret to without the mount prefix. For example, if you want to write to 'secrets/application/credentials', this should be 'application/credentials'.")),
 			mcp.WithString("key", mcp.Required(), mcp.Description("The key name for the secret. For example if you want to write mysecret=myvalue, this should be 'mysecret'")),
 			mcp.WithString("value", mcp.Required(), mcp.Description("The value to store the given key. For example if you want to write mysecret=myvalue, this should be 'myvalue'")),
@@ -33,30 +33,29 @@ func writeSecretHandler(ctx context.Context, req mcp.CallToolRequest, logger *lo
 	logger.Debug("Handling write_secret request")
 
 	// Extract parameters
-	var mount, path, key, value string
+	args, ok := req.Params.Arguments.(map[string]interface{})
+	if !ok {
+		return mcp.NewToolResultError("Missing or invalid arguments format"), nil
+	}
 
-	if req.Params.Arguments != nil {
-		if args, ok := req.Params.Arguments.(map[string]interface{}); ok {
-			if mount, ok = args["mount"].(string); !ok || mount == "" {
-				return mcp.NewToolResultError("Missing or invalid 'mount' parameter"), nil
-			}
+	mount, err := extractMountPath(args)
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
 
-			if path, ok = args["path"].(string); !ok || path == "" {
-				return mcp.NewToolResultError("Missing or invalid 'path' parameter"), nil
-			}
+	path, ok := args["path"].(string)
+	if !ok || path == "" {
+		return mcp.NewToolResultError("Missing or invalid 'path' parameter"), nil
+	}
 
-			if key, ok = args["key"].(string); !ok || key == "" {
-				return mcp.NewToolResultError("Missing or invalid 'key' parameter"), nil
-			}
+	key, ok := args["key"].(string)
+	if !ok || key == "" {
+		return mcp.NewToolResultError("Missing or invalid 'key' parameter"), nil
+	}
 
-			if value, ok = args["value"].(string); !ok {
-				return mcp.NewToolResultError("Missing or invalid 'value' parameter"), nil
-			}
-		} else {
-			return mcp.NewToolResultError("Invalid arguments format"), nil
-		}
-	} else {
-		return mcp.NewToolResultError("Missing arguments"), nil
+	value, ok := args["value"].(string)
+	if !ok || value == "" {
+		return mcp.NewToolResultError("Missing or invalid 'value' parameter"), nil
 	}
 
 	logger.WithFields(log.Fields{
@@ -78,7 +77,7 @@ func writeSecretHandler(ctx context.Context, req mcp.CallToolRequest, logger *lo
 	}
 
 	// Default to a v1 KV path
-	fullPath := fmt.Sprintf("%s/%s", strings.TrimSuffix(mount, "/"), strings.TrimPrefix(path, "/"))
+	fullPath := fmt.Sprintf("%s/%s", mount, strings.TrimPrefix(path, "/"))
 
 	isV2 := false
 
@@ -88,7 +87,7 @@ func writeSecretHandler(ctx context.Context, req mcp.CallToolRequest, logger *lo
 		if m.Options["version"] == "2" {
 			isV2 = true
 			// Construct the full path for reading (KV v2 format)
-			fullPath = fmt.Sprintf("%s/data/%s", strings.TrimSuffix(mount, "/"), strings.TrimPrefix(path, "/"))
+			fullPath = fmt.Sprintf("%s/data/%s", mount, strings.TrimPrefix(path, "/"))
 		}
 	} else {
 		return mcp.NewToolResultError(fmt.Sprintf("mount path '%s' does not exist. Use 'create_mount' with the type kv2 to create the mount.", mount)), nil


### PR DESCRIPTION
## Problem Description
The `read_secret`, `list_secrets`, `write_secret` and `delete_secret` tools fail when they are called with `mount` parameter ending with `/`. Facing this problem consistently when using `GPT-4o` in VS Code Copilot Agent mode although it works well with other models.

https://github.com/user-attachments/assets/2a15f7bb-efeb-4551-900b-e481485b0fb3

## Solution
- Update tool param description to indicate `mount` shouldn't end with a trailing slash
- Remove trailing slash explicitly when extracting mount from the tool call request
  - Update the rest of the locations where are removing trailing slash as it is no longer needed 
- Minor refactoring to avoid nested if conditions

 https://github.com/user-attachments/assets/d3e919f3-8ded-4acc-8bac-e9f3c3b74cbe

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.

If you have any questions, please contact your direct supervisor, GRC (#team-grc), or the PCI working group (#proj-pci-reboot). You can also find more information at [PCI Compliance](https://hashicorp.atlassian.net/wiki/spaces/SEC/pages/2784559202/PCI+Compliance).
