### PR TITLE
Fix docker-build target by using basename for Docker tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 SHELL := /usr/bin/env bash -euo pipefail -c
 
 BINARY_NAME ?= ./bin/vault-mcp-server
+BASENAME := $(shell basename $(BINARY_NAME))
 VERSION ?= $(if $(shell printenv VERSION),$(shell printenv VERSION),dev)
 
 GO=go
@@ -49,7 +50,7 @@ deps:
 
 # Build docker image
 docker-build:
-	$(DOCKER) build --build-arg VERSION=$(VERSION) -t $(shell basename $(BINARY_NAME)):$(VERSION) .
+	$(DOCKER) build --build-arg VERSION=$(VERSION) -t $(BASENAME):$(VERSION) .
 
 # Run HTTP server locally
 run-http:
@@ -57,7 +58,7 @@ run-http:
 
 # Run HTTP server in Docker
 docker-run-http:
-	$(DOCKER) run -p 8080:8080 --rm $(shell basename $(BINARY_NAME)):$(VERSION) http
+	$(DOCKER) run -p 8080:8080 --rm $(BASENAME):$(VERSION) http
 
 # Test HTTP endpoint
 test-http:
@@ -72,8 +73,8 @@ test-http:
 # Clean up test containers
 cleanup-test-containers:
 	@echo "Cleaning up test containers..."
-	@$(DOCKER) ps -q --filter "ancestor=$(shell basename $(BINARY_NAME)):test-e2e" | xargs -r $(DOCKER) stop
-	@$(DOCKER) ps -aq --filter "ancestor=$(shell basename $(BINARY_NAME)):test-e2e" | xargs -r $(DOCKER) rm
+	@$(DOCKER) ps -q --filter "ancestor=$(BASENAME):test-e2e" | xargs -r $(DOCKER) stop
+	@$(DOCKER) ps -aq --filter "ancestor=$(BASENAME):test-e2e" | xargs -r $(DOCKER) rm
 	@echo "Test container cleanup complete"
 
 # Show help


### PR DESCRIPTION
The docker-build target was failing because BINARY_NAME includes a path
(./bin/vault-mcp-server) which creates invalid Docker tags. Fixed by using
basename to extract just the filename for the Docker tag.

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.

If you have any questions, please contact your direct supervisor, GRC (#team-grc), or the PCI working group (#proj-pci-reboot). You can also find more information at [PCI Compliance](https://hashicorp.atlassian.net/wiki/spaces/SEC/pages/2784559202/PCI+Compliance).
