### PR TITLE
README.md updated with support section

### DIFF
--- a/README.md
+++ b/README.md
@@ -423,3 +423,9 @@ vault-mcp-server/
 ├── go.mod                                # Go module definition
 └── LICENSE                               # License information
 ```
+
+## Support
+
+For bug reports and feature requests, please open an [issue on GitHub](https://github.com/hashicorp/vault-mcp-server/issues).
+
+For general questions and discussions, open a GitHub Discussion.


### PR DESCRIPTION
Added link to [vault-mcp-server **Issues**](https://github.com/hashicorp/vault-mcp-server/issues) in Support section at the end of README.md.

<img width="2328" height="1064" alt="image" src="https://github.com/user-attachments/assets/89a3ca52-8174-4fbf-99aa-9b4d6b21717a" />
