### PR TITLE
fix: read VAULT_SKIP_VERIFY from environment as fallback

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -127,15 +127,34 @@ func CreateVaultClientForSession(ctx context.Context, session server.ClientSessi
 	}
 
 	var vaultSkipTLSVerify bool
+	skipProvidedInContext := false
 	skipTLSVal := ctx.Value(contextKey(VaultSkipTLSVerify))
 	if skipTLSVal != nil {
 		skipTLSStr, ok := skipTLSVal.(string)
 		if ok {
-			vaultSkipTLSVerify, _ = strconv.ParseBool(skipTLSStr)
+			parsed, err := strconv.ParseBool(skipTLSStr)
+			if err != nil {
+				logger.WithFields(log.Fields{
+					"session_id": session.SessionID(),
+					"value":      skipTLSStr,
+				}).Warn("Invalid boolean value for VaultSkipTLSVerify in context; using default")
+			} else {
+				vaultSkipTLSVerify = parsed
+				skipProvidedInContext = true
+			}
 		}
 	}
-	if !vaultSkipTLSVerify {
-		vaultSkipTLSVerify, _ = strconv.ParseBool(getEnv(VaultSkipTLSVerify, "false"))
+	if !skipProvidedInContext {
+		envVal := getEnv(VaultSkipTLSVerify, "false")
+		parsed, err := strconv.ParseBool(envVal)
+		if err != nil {
+			logger.WithFields(log.Fields{
+				"session_id": session.SessionID(),
+				"value":      envVal,
+			}).Warn("Invalid boolean value for VAULT_SKIP_VERIFY; using existing value")
+		} else {
+			vaultSkipTLSVerify = parsed
+		}
 	}
 
 	newClient, err := NewVaultClient(session.SessionID(), vaultAddress, vaultSkipTLSVerify, vaultToken, vaultNamespace)

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -137,7 +137,7 @@ func CreateVaultClientForSession(ctx context.Context, session server.ClientSessi
 				logger.WithFields(log.Fields{
 					"session_id": session.SessionID(),
 					"value":      skipTLSStr,
-				}).Warn("Invalid boolean value for VaultSkipTLSVerify in context; using default")
+				}).Warn("Invalid boolean value for VaultSkipTLSVerify in context; falling back to VAULT_SKIP_VERIFY or its default")
 			} else {
 				vaultSkipTLSVerify = parsed
 				skipProvidedInContext = true

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -151,7 +151,7 @@ func CreateVaultClientForSession(ctx context.Context, session server.ClientSessi
 			logger.WithFields(log.Fields{
 				"session_id": session.SessionID(),
 				"value":      envVal,
-			}).Warn("Invalid boolean value for VAULT_SKIP_VERIFY; using existing value")
+		}).Warn("Invalid boolean value for VAULT_SKIP_VERIFY; using default value false")
 		} else {
 			vaultSkipTLSVerify = parsed
 		}

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -134,6 +134,9 @@ func CreateVaultClientForSession(ctx context.Context, session server.ClientSessi
 			vaultSkipTLSVerify, _ = strconv.ParseBool(skipTLSStr)
 		}
 	}
+	if !vaultSkipTLSVerify {
+		vaultSkipTLSVerify, _ = strconv.ParseBool(getEnv(VaultSkipTLSVerify, "false"))
+	}
 
 	newClient, err := NewVaultClient(session.SessionID(), vaultAddress, vaultSkipTLSVerify, vaultToken, vaultNamespace)
 	if err != nil {

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -4,11 +4,14 @@
 package client
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"testing"
 
+	"github.com/hashicorp/vault/api"
+	"github.com/mark3labs/mcp-go/mcp"
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 )
@@ -55,6 +58,113 @@ func TestNewVaultClient(t *testing.T) {
 		// Clean up
 		DeleteVaultClient(sessionID)
 	}
+}
+
+// mockClientSession implements server.ClientSession for testing.
+type mockClientSession struct {
+	id string
+}
+
+func (m *mockClientSession) Initialize()                                        {}
+func (m *mockClientSession) Initialized() bool                                  { return true }
+func (m *mockClientSession) NotificationChannel() chan<- mcp.JSONRPCNotification { return make(chan mcp.JSONRPCNotification, 1) }
+func (m *mockClientSession) SessionID() string                                  { return m.id }
+
+func TestCreateVaultClientForSession_SkipTLSVerify(t *testing.T) {
+	logger := log.New()
+	logger.SetLevel(log.WarnLevel)
+
+	newCtx := func(vals map[contextKey]string) context.Context {
+		ctx := context.Background()
+		for k, v := range vals {
+			ctx = context.WithValue(ctx, k, v)
+		}
+		return ctx
+	}
+
+	getTLSSkip := func(t *testing.T, c *api.Client) bool {
+		t.Helper()
+		httpClient := c.CloneConfig().HttpClient
+		tr, ok := httpClient.Transport.(*http.Transport)
+		if !ok || tr.TLSClientConfig == nil {
+			return false
+		}
+		return tr.TLSClientConfig.InsecureSkipVerify
+	}
+
+	baseCtx := map[contextKey]string{
+		contextKey(VaultAddress): "http://127.0.0.1:8200",
+		contextKey(VaultToken):   "test-token",
+	}
+
+	t.Run("env var fallback when context key absent", func(t *testing.T) {
+		os.Setenv(VaultSkipTLSVerify, "true")
+		defer os.Unsetenv(VaultSkipTLSVerify)
+
+		session := &mockClientSession{id: "test-env-fallback"}
+		client, err := CreateVaultClientForSession(newCtx(baseCtx), session, logger)
+		assert.NoError(t, err)
+		assert.True(t, getTLSSkip(t, client), "expected InsecureSkipVerify=true from env fallback")
+		DeleteVaultClient(session.id)
+	})
+
+	t.Run("context true takes precedence over env false", func(t *testing.T) {
+		os.Setenv(VaultSkipTLSVerify, "false")
+		defer os.Unsetenv(VaultSkipTLSVerify)
+
+		ctxVals := map[contextKey]string{
+			contextKey(VaultAddress):      "http://127.0.0.1:8200",
+			contextKey(VaultToken):        "test-token",
+			contextKey(VaultSkipTLSVerify): "true",
+		}
+		session := &mockClientSession{id: "test-ctx-true-env-false"}
+		client, err := CreateVaultClientForSession(newCtx(ctxVals), session, logger)
+		assert.NoError(t, err)
+		assert.True(t, getTLSSkip(t, client), "context true should win over env false")
+		DeleteVaultClient(session.id)
+	})
+
+	t.Run("context false takes precedence over env true", func(t *testing.T) {
+		os.Setenv(VaultSkipTLSVerify, "true")
+		defer os.Unsetenv(VaultSkipTLSVerify)
+
+		ctxVals := map[contextKey]string{
+			contextKey(VaultAddress):      "http://127.0.0.1:8200",
+			contextKey(VaultToken):        "test-token",
+			contextKey(VaultSkipTLSVerify): "false",
+		}
+		session := &mockClientSession{id: "test-ctx-false-env-true"}
+		client, err := CreateVaultClientForSession(newCtx(ctxVals), session, logger)
+		assert.NoError(t, err)
+		assert.False(t, getTLSSkip(t, client), "context false should win over env true")
+		DeleteVaultClient(session.id)
+	})
+
+	t.Run("defaults to false when neither context nor env set", func(t *testing.T) {
+		os.Unsetenv(VaultSkipTLSVerify)
+
+		session := &mockClientSession{id: "test-default-false"}
+		client, err := CreateVaultClientForSession(newCtx(baseCtx), session, logger)
+		assert.NoError(t, err)
+		assert.False(t, getTLSSkip(t, client), "should default to InsecureSkipVerify=false")
+		DeleteVaultClient(session.id)
+	})
+
+	t.Run("invalid context value falls back to env", func(t *testing.T) {
+		os.Setenv(VaultSkipTLSVerify, "true")
+		defer os.Unsetenv(VaultSkipTLSVerify)
+
+		ctxVals := map[contextKey]string{
+			contextKey(VaultAddress):      "http://127.0.0.1:8200",
+			contextKey(VaultToken):        "test-token",
+			contextKey(VaultSkipTLSVerify): "not-a-bool",
+		}
+		session := &mockClientSession{id: "test-invalid-ctx"}
+		client, err := CreateVaultClientForSession(newCtx(ctxVals), session, logger)
+		assert.NoError(t, err)
+		assert.True(t, getTLSSkip(t, client), "invalid context should fall back to env=true")
+		DeleteVaultClient(session.id)
+	})
 }
 
 func TestVaultNamespaceSupport(t *testing.T) {

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -98,8 +98,7 @@ func TestCreateVaultClientForSession_SkipTLSVerify(t *testing.T) {
 	}
 
 	t.Run("env var fallback when context key absent", func(t *testing.T) {
-		os.Setenv(VaultSkipTLSVerify, "true")
-		defer os.Unsetenv(VaultSkipTLSVerify)
+		t.Setenv(VaultSkipTLSVerify, "true")
 
 		session := &mockClientSession{id: "test-env-fallback"}
 		client, err := CreateVaultClientForSession(newCtx(baseCtx), session, logger)
@@ -109,8 +108,7 @@ func TestCreateVaultClientForSession_SkipTLSVerify(t *testing.T) {
 	})
 
 	t.Run("context true takes precedence over env false", func(t *testing.T) {
-		os.Setenv(VaultSkipTLSVerify, "false")
-		defer os.Unsetenv(VaultSkipTLSVerify)
+		t.Setenv(VaultSkipTLSVerify, "false")
 
 		ctxVals := map[contextKey]string{
 			contextKey(VaultAddress):      "http://127.0.0.1:8200",
@@ -125,8 +123,7 @@ func TestCreateVaultClientForSession_SkipTLSVerify(t *testing.T) {
 	})
 
 	t.Run("context false takes precedence over env true", func(t *testing.T) {
-		os.Setenv(VaultSkipTLSVerify, "true")
-		defer os.Unsetenv(VaultSkipTLSVerify)
+		t.Setenv(VaultSkipTLSVerify, "true")
 
 		ctxVals := map[contextKey]string{
 			contextKey(VaultAddress):      "http://127.0.0.1:8200",
@@ -141,7 +138,13 @@ func TestCreateVaultClientForSession_SkipTLSVerify(t *testing.T) {
 	})
 
 	t.Run("defaults to false when neither context nor env set", func(t *testing.T) {
+		prevVal, wasSet := os.LookupEnv(VaultSkipTLSVerify)
 		os.Unsetenv(VaultSkipTLSVerify)
+		t.Cleanup(func() {
+			if wasSet {
+				os.Setenv(VaultSkipTLSVerify, prevVal)
+			}
+		})
 
 		session := &mockClientSession{id: "test-default-false"}
 		client, err := CreateVaultClientForSession(newCtx(baseCtx), session, logger)
@@ -151,8 +154,7 @@ func TestCreateVaultClientForSession_SkipTLSVerify(t *testing.T) {
 	})
 
 	t.Run("invalid context value falls back to env", func(t *testing.T) {
-		os.Setenv(VaultSkipTLSVerify, "true")
-		defer os.Unsetenv(VaultSkipTLSVerify)
+		t.Setenv(VaultSkipTLSVerify, "true")
 
 		ctxVals := map[contextKey]string{
 			contextKey(VaultAddress):      "http://127.0.0.1:8200",


### PR DESCRIPTION
The skip-TLS flag was only read from the MCP context, not from environment variables. Unlike VAULT_ADDR and VAULT_TOKEN which had getEnv fallbacks, VAULT_SKIP_VERIFY did not, so the env var passed by vault-lens was silently ignored.

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.

If you have any questions, please contact your direct supervisor, GRC (#team-grc), or the PCI working group (#proj-pci-reboot). You can also find more information at [PCI Compliance](https://hashicorp.atlassian.net/wiki/spaces/SEC/pages/2784559202/PCI+Compliance).
