### PR TITLE
Run runtime images as non-root for Kubernetes compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+
+* Run as a non-root user for Kubernetes compatibility.
+
 ## 0.2.1
 
 FEATURES

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,6 +39,8 @@ WORKDIR /server
 # Copy the binary from the build stage
 COPY --from=devbuild /build/vault-mcp-server .
 COPY --from=certbuild /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+# Run as a non-root user for Kubernetes compatibility.
+USER 65532:65532
 # Command to run the server
 CMD ["./vault-mcp-server", "stdio"]
 
@@ -63,6 +65,8 @@ LABEL version=$PRODUCT_VERSION
 LABEL revision=$PRODUCT_REVISION
 COPY dist/$TARGETOS/$TARGETARCH/$BIN_NAME /bin/vault-mcp-server
 COPY --from=certbuild /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+# Run as a non-root user for Kubernetes compatibility.
+USER 65532:65532
 CMD ["/bin/vault-mcp-server", "stdio"]
 
 # ===================================


### PR DESCRIPTION
Problem: runtime images execute as root by default, which can conflict with Kubernetes best practice and runAsNonRoot policies

Change: set USER 65532:65532 in both runnable stages (dev and release-default) in [Dockerfile]

Impact: security hardening only; command behavior remains unchanged.

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] I have documented a clear reason for, and description of, the change I am making.

- [x] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [x] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.

If you have any questions, please contact your direct supervisor, GRC (#team-grc), or the PCI working group (#proj-pci-reboot). You can also find more information at [PCI Compliance](https://hashicorp.atlassian.net/wiki/spaces/SEC/pages/2784559202/PCI+Compliance).
