### PR TITLE
Add optional namespace override to KV tools

### DIFF
--- a/pkg/tools/kv/delete_secret.go
+++ b/pkg/tools/kv/delete_secret.go
@@ -38,6 +38,10 @@ func DeleteSecret(logger *log.Logger) server.ServerTool {
 				mcp.DefaultString(""),
 				mcp.Description("A optional key in the secret to delete. If not specified, all keys in the the secret will be deleted."),
 			),
+			mcp.WithString("namespace",
+				mcp.DefaultString(""),
+				mcp.Description("Optional Vault namespace override for this call (for example: 'admin/team-03'). If not set, uses the MCP session namespace."),
+			),
 		),
 		Handler: func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 			return deleteSecretHandler(ctx, req, logger)
@@ -69,6 +73,7 @@ func deleteSecretHandler(ctx context.Context, req mcp.CallToolRequest, logger *l
 	if !ok {
 		return mcp.NewToolResultError("Missing or invalid 'key' parameter"), nil
 	}
+	namespace, _ := args["namespace"].(string)
 
 	logger.WithFields(log.Fields{
 		"mount": mount,
@@ -82,6 +87,7 @@ func deleteSecretHandler(ctx context.Context, req mcp.CallToolRequest, logger *l
 		logger.WithError(err).Error("Failed to get Vault client")
 		return mcp.NewToolResultError(fmt.Sprintf("Failed to get Vault client: %v", err)), nil
 	}
+	vault = withOptionalNamespace(vault, namespace)
 
 	mounts, err := vault.Sys().ListMounts()
 	if err != nil {

--- a/pkg/tools/kv/list_secrets.go
+++ b/pkg/tools/kv/list_secrets.go
@@ -33,6 +33,10 @@ func ListSecrets(logger *log.Logger) server.ServerTool {
 			mcp.WithString("path",
 				mcp.DefaultString(""),
 				mcp.Description("The full path to list the secrets to without the mount prefix. For example, if you want to list from 'secrets/application/credentials', this should be 'application/credentials'.")),
+			mcp.WithString("namespace",
+				mcp.DefaultString(""),
+				mcp.Description("Optional Vault namespace override for this call (for example: 'admin/team-03'). If not set, uses the MCP session namespace."),
+			),
 		),
 		Handler: func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 			return listSecretsHandler(ctx, req, logger)
@@ -58,6 +62,7 @@ func listSecretsHandler(ctx context.Context, req mcp.CallToolRequest, logger *lo
 	if path == "" {
 		path = ""
 	}
+	namespace, _ := args["namespace"].(string)
 
 	logger.WithFields(log.Fields{
 		"mount": mount,
@@ -70,6 +75,7 @@ func listSecretsHandler(ctx context.Context, req mcp.CallToolRequest, logger *lo
 		logger.WithError(err).Error("Failed to get Vault client")
 		return mcp.NewToolResultError(fmt.Sprintf("Failed to get Vault client: %v", err)), nil
 	}
+	vault = withOptionalNamespace(vault, namespace)
 
 	// Construct the full path for listing
 	fullPath := fmt.Sprintf(mount+"/%s", path)

--- a/pkg/tools/kv/namespace.go
+++ b/pkg/tools/kv/namespace.go
@@ -1,0 +1,18 @@
+// Copyright IBM Corp. 2025, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package kv
+
+import (
+	"strings"
+
+	"github.com/hashicorp/vault/api"
+)
+
+func withOptionalNamespace(vault *api.Client, namespace string) *api.Client {
+	ns := strings.TrimSpace(namespace)
+	if ns == "" {
+		return vault
+	}
+	return vault.WithNamespace(ns)
+}

--- a/pkg/tools/kv/read_secret.go
+++ b/pkg/tools/kv/read_secret.go
@@ -30,6 +30,10 @@ func ReadSecret(logger *log.Logger) server.ServerTool {
 				mcp.Required(),
 				mcp.Description("The full path to read the secret to without the mount prefix. For example, if you want to read from 'secrets/application/credentials', this should be 'application/credentials'."),
 			),
+			mcp.WithString("namespace",
+				mcp.DefaultString(""),
+				mcp.Description("Optional Vault namespace override for this call (for example: 'admin/team-03'). If not set, uses the MCP session namespace."),
+			),
 		),
 		Handler: func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 			return readSecretHandler(ctx, req, logger)
@@ -55,6 +59,7 @@ func readSecretHandler(ctx context.Context, req mcp.CallToolRequest, logger *log
 	if !ok || path == "" {
 		return mcp.NewToolResultError("Missing or invalid 'path' parameter"), nil
 	}
+	namespace, _ := args["namespace"].(string)
 
 	logger.WithFields(log.Fields{
 		"mount": mount,
@@ -67,6 +72,7 @@ func readSecretHandler(ctx context.Context, req mcp.CallToolRequest, logger *log
 		logger.WithError(err).Error("Failed to get Vault client")
 		return mcp.NewToolResultError(fmt.Sprintf("Failed to get Vault client: %v", err)), nil
 	}
+	vault = withOptionalNamespace(vault, namespace)
 
 	mounts, err := vault.Sys().ListMounts()
 	if err != nil {

--- a/pkg/tools/kv/write_secret.go
+++ b/pkg/tools/kv/write_secret.go
@@ -43,6 +43,10 @@ func WriteSecret(logger *log.Logger) server.ServerTool {
 				mcp.Required(),
 				mcp.Description("The value to store the given key. For example if you want to write mysecret=myvalue, this should be 'myvalue'"),
 			),
+			mcp.WithString("namespace",
+				mcp.DefaultString(""),
+				mcp.Description("Optional Vault namespace override for this call (for example: 'admin/team-03'). If not set, uses the MCP session namespace."),
+			),
 		),
 		Handler: func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 			return writeSecretHandler(ctx, req, logger)
@@ -78,6 +82,7 @@ func writeSecretHandler(ctx context.Context, req mcp.CallToolRequest, logger *lo
 	if !ok || value == "" {
 		return mcp.NewToolResultError("Missing or invalid 'value' parameter"), nil
 	}
+	namespace, _ := args["namespace"].(string)
 
 	logger.WithFields(log.Fields{
 		"mount": mount,
@@ -91,6 +96,7 @@ func writeSecretHandler(ctx context.Context, req mcp.CallToolRequest, logger *lo
 		logger.WithError(err).Error("Failed to get Vault client")
 		return mcp.NewToolResultError(fmt.Sprintf("Failed to get Vault client: %v", err)), nil
 	}
+	vault = withOptionalNamespace(vault, namespace)
 
 	mounts, err := vault.Sys().ListMounts()
 	if err != nil {


### PR DESCRIPTION
## Summary
Adds an optional  parameter to the existing KV tools so callers can target a different Vault namespace per request without changing the MCP session namespace.

## Changes
- add  to 
- add  to 
- add  to 
- add  to 
- factor namespace application into a small helper

## Why
This supports multi-namespace workflows from a single MCP session and avoids having to reconfigure the server between calls.

## Validation
- ok  	github.com/hashicorp/vault-mcp-server/pkg/tools/kv	(cached)
