### PR TITLE
feat(kv): include KV v2 metadata (custom_metadata, version) in read_secret

### DIFF
--- a/pkg/tools/kv/read_secret.go
+++ b/pkg/tools/kv/read_secret.go
@@ -127,7 +127,13 @@ func readSecretHandler(ctx context.Context, req mcp.CallToolRequest, logger *log
 		if !ok {
 			return mcp.NewToolResultError("unexpected secret data format for v2 API"), nil
 		}
-		secretData = data
+		// Include the KV v2 metadata block (version, created/updated times and
+		// custom_metadata such as description/usage) alongside the data payload,
+		// instead of discarding it — clients need it to understand a secret.
+		secretData = map[string]interface{}{
+			"data":     data,
+			"metadata": secret.Data["metadata"],
+		}
 	} else {
 		// V1 API structure: secret.Data directly contains the key-value pairs
 		secretData = secret.Data


### PR DESCRIPTION
## Problem

`read_secret` on a KV v2 mount returns only the data payload (`secret.Data["data"]`) and discards `secret.Data["metadata"]`. MCP clients therefore cannot see a secret's version, created/updated timestamps, or **custom_metadata** (e.g. `description`/`usage`) — even though Vault returns all of it in the same data-endpoint response.

## Change

Return `{"data": ..., "metadata": ...}` for KV v2 reads, keeping the values while surfacing the metadata block. KV v1 behaviour is unchanged.

## Why it matters

Teams often store human context (what a secret is for, where it's used) in `custom_metadata`. Without it an agent reading a secret has no idea what it is; this makes that context available.