### PR TITLE
feat(tools): implement ENABLE_VAULT_OPERATIONS to gate mutating tools

### DIFF
--- a/pkg/tools/tools.go
+++ b/pkg/tools/tools.go
@@ -4,6 +4,9 @@
 package tools
 
 import (
+	"os"
+	"strconv"
+
 	"github.com/hashicorp/vault-mcp-server/pkg/tools/kv"
 	"github.com/hashicorp/vault-mcp-server/pkg/tools/pki"
 	"github.com/hashicorp/vault-mcp-server/pkg/tools/sys"
@@ -11,37 +14,39 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-func InitTools(hcServer *server.MCPServer, logger *log.Logger) {
+// vaultOperationsEnabled reports whether mutating (write / delete / create)
+// tools should be registered. Controlled by the ENABLE_VAULT_OPERATIONS
+// environment variable and defaults to false — when unset or false, only
+// read-only tools are exposed, so a read-only Vault token cannot be tricked
+// into attempting privileged operations that the surface should not offer.
+func vaultOperationsEnabled() bool {
+	v := os.Getenv("ENABLE_VAULT_OPERATIONS")
+	if v == "" {
+		return false
+	}
+	enabled, err := strconv.ParseBool(v)
+	if err != nil {
+		return false
+	}
+	return enabled
+}
 
-	// Tools for Vault mount management
+func InitTools(hcServer *server.MCPServer, logger *log.Logger) {
+	writeEnabled := vaultOperationsEnabled()
+	if !writeEnabled {
+		logger.Info("ENABLE_VAULT_OPERATIONS is not true; registering read-only tools only")
+	}
+
+	// ---- Read-only tools (always registered) ----
+
 	listMountsTool := sys.ListMounts(logger)
 	hcServer.AddTool(listMountsTool.Tool, listMountsTool.Handler)
 
-	createMountTool := sys.CreateMount(logger)
-	hcServer.AddTool(createMountTool.Tool, createMountTool.Handler)
-
-	deleteMountTool := sys.DeleteMount(logger)
-	hcServer.AddTool(deleteMountTool.Tool, deleteMountTool.Handler)
-
-	// Tools for KV secrets management
 	listSecretsTool := kv.ListSecrets(logger)
 	hcServer.AddTool(listSecretsTool.Tool, listSecretsTool.Handler)
 
 	readSecretTool := kv.ReadSecret(logger)
 	hcServer.AddTool(readSecretTool.Tool, readSecretTool.Handler)
-
-	writeSecretTool := kv.WriteSecret(logger)
-	hcServer.AddTool(writeSecretTool.Tool, writeSecretTool.Handler)
-
-	deleteSecretTool := kv.DeleteSecret(logger)
-	hcServer.AddTool(deleteSecretTool.Tool, deleteSecretTool.Handler)
-
-	// Tools for PKI management
-	enablePkiTool := pki.EnablePki(logger)
-	hcServer.AddTool(enablePkiTool.Tool, enablePkiTool.Handler)
-
-	createPkiIssuer := pki.CreatePkiIssuer(logger)
-	hcServer.AddTool(createPkiIssuer.Tool, createPkiIssuer.Handler)
 
 	listPkiIssuers := pki.ListPkiIssuers(logger)
 	hcServer.AddTool(listPkiIssuers.Tool, listPkiIssuers.Handler)
@@ -54,6 +59,30 @@ func InitTools(hcServer *server.MCPServer, logger *log.Logger) {
 
 	readPkiRole := pki.ReadPkiRole(logger)
 	hcServer.AddTool(readPkiRole.Tool, readPkiRole.Handler)
+
+	// ---- Mutating tools (only when ENABLE_VAULT_OPERATIONS=true) ----
+
+	if !writeEnabled {
+		return
+	}
+
+	createMountTool := sys.CreateMount(logger)
+	hcServer.AddTool(createMountTool.Tool, createMountTool.Handler)
+
+	deleteMountTool := sys.DeleteMount(logger)
+	hcServer.AddTool(deleteMountTool.Tool, deleteMountTool.Handler)
+
+	writeSecretTool := kv.WriteSecret(logger)
+	hcServer.AddTool(writeSecretTool.Tool, writeSecretTool.Handler)
+
+	deleteSecretTool := kv.DeleteSecret(logger)
+	hcServer.AddTool(deleteSecretTool.Tool, deleteSecretTool.Handler)
+
+	enablePkiTool := pki.EnablePki(logger)
+	hcServer.AddTool(enablePkiTool.Tool, enablePkiTool.Handler)
+
+	createPkiIssuer := pki.CreatePkiIssuer(logger)
+	hcServer.AddTool(createPkiIssuer.Tool, createPkiIssuer.Handler)
 
 	createPkiRole := pki.CreatePkiRole(logger)
 	hcServer.AddTool(createPkiRole.Tool, createPkiRole.Handler)


### PR DESCRIPTION
## Problem

The [security model docs](https://developer.hashicorp.com/vault/docs/mcp-server/security-model) recommend setting `ENABLE_VAULT_OPERATIONS=false` "if write access isn't needed", but the variable is not implemented — `InitTools` registers every tool unconditionally, so a read-only deployment still exposes `write_secret`, `delete_secret`, `create_mount`, `delete_mount` and the PKI-write tools.

## Change

Implement the documented flag. Mutating tools (write/delete/create + PKI enable/issue) register only when `ENABLE_VAULT_OPERATIONS=true`. Default is read-only: `list_mounts`, `list_secrets`, `read_secret`, plus PKI reads.

## Why it matters

Operators with read-only use cases can now actually restrict the tool surface, matching what the security-model documentation already promises.