### PR TITLE
VAULT-48712: block VAULT_ADDR from URL query parameters to prevent SSRF

### DIFF
--- a/pkg/client/middleware.go
+++ b/pkg/client/middleware.go
@@ -152,6 +152,13 @@ func VaultContextMiddleware(logger *log.Logger) func(http.Handler) http.Handler 
 						http.Error(w, "Vault token should not be provided in query parameters for security reasons, use the X-Vault-Token header", http.StatusBadRequest)
 						return
 					}
+	
+					// Explicitly disallow VAULT_ADDR in query parameters to prevent SSRF and token theft
+					if header == VaultAddress && headerValue != "" {
+						logger.Info(fmt.Sprintf("Vault address was provided in query parameters by client %v, terminating request", r.RemoteAddr))
+						http.Error(w, "Vault address should not be provided in query parameters for security reasons, use the VAULT_ADDR header", http.StatusBadRequest)
+						return
+					}
 				}
 
 				// If not found in query parameters, check environment variables

--- a/pkg/client/middleware_test.go
+++ b/pkg/client/middleware_test.go
@@ -549,6 +549,25 @@ func TestVaultContextMiddleware_EdgeCases(t *testing.T) {
 		assert.Contains(t, rr.Body.String(), "Vault token should not be provided in query parameters")
 	})
 
+	t.Run("vault address in query parameters is rejected for security", func(t *testing.T) {
+		mockHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		})
+
+		middleware := VaultContextMiddleware(logger)
+		handler := middleware(mockHandler)
+
+		// Create request with VAULT_ADDR in query parameters (should be rejected)
+		req := httptest.NewRequest("GET", "/mcp?VAULT_ADDR=http://attacker.com:8200", nil)
+
+		rr := httptest.NewRecorder()
+		handler.ServeHTTP(rr, req)
+
+		// Should return 400 Bad Request for security reasons
+		assert.Equal(t, http.StatusBadRequest, rr.Code)
+		assert.Contains(t, rr.Body.String(), "Vault address should not be provided in query parameters")
+	})
+
 	t.Run("very long header values are handled", func(t *testing.T) {
 		mockHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			ctx := r.Context()


### PR DESCRIPTION
## Summary

The Vault MCP server accepted `VAULT_ADDR` as a URL query parameter, allowing any client to redirect the server's Vault API requests to an arbitrary host. This PR blocks `VAULT_ADDR` from being supplied via query parameter, the same way `VAULT_TOKEN` was already blocked.

## Problem

`VaultContextMiddleware` resolved `VAULT_ADDR` from HTTP headers, query parameters, and environment variables — in that order. There was no guard on the query parameter path for `VAULT_ADDR`, meaning any client could inject:

?VAULT_ADDR=http://attacker-controlled-host


This enabled two attacks:

- **SSRF** — The MCP server makes Vault API requests to an arbitrary host on the attacker's behalf, allowing them to probe internal services unreachable from outside the network
- **Token theft** — When the server has `VAULT_TOKEN` set as an env var and the attacker supplies no token, the server falls back to its own token and sends it to the attacker-controlled host

This is the same vulnerability as terraform-mcp-server CVE-2026-14869.

## Error Scenario
### Sending a http request with ADDR
<img width="468" height="109" alt="image" src="https://github.com/user-attachments/assets/909c5f72-ef7f-495d-bca8-e42551d21ae5" />

### SSRF (Temp server receiving request from MCP server
<img width="468" height="152" alt="image" src="https://github.com/user-attachments/assets/b1cb3498-6749-492d-83e8-c1b77b768334" />



## Fix

Added a check in `VaultContextMiddleware` to reject any request that supplies `VAULT_ADDR` as a query parameter, returning `400 Bad Request`. This mirrors the existing check for `VAULT_TOKEN`.

`VAULT_ADDR` can still be supplied via HTTP header for legitimate multi-tenant use cases.

## Changes

- **`pkg/client/middleware.go`**: Block `VAULT_ADDR` from URL query parameters — 6 lines added, no existing code changed

### Fix Scenario
Sending ADDR http request and getting refusal
<img width="468" height="136" alt="image" src="https://github.com/user-attachments/assets/d79997d6-c513-419d-a838-3e65cc84e426" />

The temp server does not get any request
<img width="468" height="130" alt="image" src="https://github.com/user-attachments/assets/0c43c624-94fe-4b5f-b4de-3618b1d8ade7" />
SSRF Prevented

Happy Path

Initializing connection and Getting MCP session ID
<img width="2016" height="206" alt="image" src="https://github.com/user-attachments/assets/8d0386c5-3593-4974-b9ad-784be50ff442" />

Listing Mounts to show the Header does not have the VAULT_ADDR attached to it.
<img width="2020" height="436" alt="image" src="https://github.com/user-attachments/assets/3619cf06-83e8-41ef-b72b-a48d38e35f53" />


## Test Plan

- [ ] Start MCP server with `VAULT_TOKEN` and `VAULT_ADDR` set
- [ ] Send request with `?VAULT_ADDR=http://attacker-host` — expect `400 Bad Request`
- [ ] Send request with `VAULT_ADDR` in HTTP header — expect normal operation
- [ ] Send request with no `VAULT_ADDR` override — expect normal operation

## Notes for Reviewers

The fix is intentionally minimal — a single `if` block mirroring the existing `VAULT_TOKEN` query parameter guard directly above it in the same function.

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.

If you have any questions, please contact your direct supervisor, GRC (#team-grc), or the PCI working group (#proj-pci-reboot). You can also find more information at [PCI Compliance](https://hashicorp.atlassian.net/wiki/spaces/SEC/pages/2784559202/PCI+Compliance).
