### PR TITLE
VAULT-48712:  update HTTP mode config to use VAULT_ADDR header instead of query param in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,12 @@ The HTTP server includes a comprehensive middleware stack:
             },
             {
                 "type": "promptString",
+                "id": "vault_addr",
+                "description": "Vault Address (e.g. http://127.0.0.1:8200)",
+                "password": false
+            },
+            {
+                "type": "promptString",
                 "id": "vault_namespace",
                 "description": "Vault Namespace (optional)",
                 "password": false
@@ -123,8 +129,9 @@ The HTTP server includes a comprehensive middleware stack:
             ],
             "servers": {
                 "vault-mcp-server": {
-                    "url": "http://localhost:8080/mcp?VAULT_ADDR=http://127.0.0.1:8200",
+                    "url": "http://localhost:8080/mcp",
                     "headers": {
+                        "VAULT_ADDR": "${input:vault_addr}",
                         "X-Vault-Token": "${input:vault_token}",
                         "X-Vault-Namespace": "${input:vault_namespace}"
                     }

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ In HTTP mode, Vault configuration can be provided through multiple methods (in o
 - **HTTP Headers**: `VAULT_ADDR`, `X-Vault-Token`, and `X-Vault-Namespace`
 - **Environment Variables**: Standard `VAULT_ADDR`, `VAULT_TOKEN`, and `VAULT_NAMESPACE` env vars
 
-> **Note:** `VAULT_ADDR` must not be supplied as a URL query parameter. Use the `VAULT_ADDR` HTTP header instead.
+> **Note:**  Do not supply `VAULT_ADDR` as a URL query parameter. Use the `VAULT_ADDR` HTTP header instead.
 
 ### Middleware Stack
 

--- a/README.md
+++ b/README.md
@@ -84,9 +84,10 @@ The server can be configured using environment variables:
 
 In HTTP mode, Vault configuration can be provided through multiple methods (in order of precedence):
 
-- **HTTP Query**: `VAULT_ADDR`
 - **HTTP Headers**: `VAULT_ADDR`, `X-Vault-Token`, and `X-Vault-Namespace`
 - **Environment Variables**: Standard `VAULT_ADDR`, `VAULT_TOKEN`, and `VAULT_NAMESPACE` env vars
+
+> **Note:** `VAULT_ADDR` must not be supplied as a URL query parameter. Use the `VAULT_ADDR` HTTP header instead.
 
 ### Middleware Stack
 
@@ -116,6 +117,12 @@ The HTTP server includes a comprehensive middleware stack:
             },
             {
                 "type": "promptString",
+                "id": "vault_addr",
+                "description": "Vault Address (e.g. http://127.0.0.1:8200)",
+                "password": false
+            },
+            {
+                "type": "promptString",
                 "id": "vault_namespace",
                 "description": "Vault Namespace (optional)",
                 "password": false
@@ -123,8 +130,9 @@ The HTTP server includes a comprehensive middleware stack:
             ],
             "servers": {
                 "vault-mcp-server": {
-                    "url": "http://localhost:8080/mcp?VAULT_ADDR=http://127.0.0.1:8200",
+                    "url": "http://localhost:8080/mcp",
                     "headers": {
+                        "VAULT_ADDR": "${input:vault_addr}",
                         "X-Vault-Token": "${input:vault_token}",
                         "X-Vault-Namespace": "${input:vault_namespace}"
                     }

--- a/README.md
+++ b/README.md
@@ -116,12 +116,6 @@ The HTTP server includes a comprehensive middleware stack:
             },
             {
                 "type": "promptString",
-                "id": "vault_addr",
-                "description": "Vault Address (e.g. http://127.0.0.1:8200)",
-                "password": false
-            },
-            {
-                "type": "promptString",
                 "id": "vault_namespace",
                 "description": "Vault Namespace (optional)",
                 "password": false
@@ -129,9 +123,8 @@ The HTTP server includes a comprehensive middleware stack:
             ],
             "servers": {
                 "vault-mcp-server": {
-                    "url": "http://localhost:8080/mcp",
+                    "url": "http://localhost:8080/mcp?VAULT_ADDR=http://127.0.0.1:8200",
                     "headers": {
-                        "VAULT_ADDR": "${input:vault_addr}",
                         "X-Vault-Token": "${input:vault_token}",
                         "X-Vault-Namespace": "${input:vault_namespace}"
                     }


### PR DESCRIPTION
Screenshot of mcp.json
<img width="1596" height="1292" alt="image" src="https://github.com/user-attachments/assets/59b7d288-2186-4fbc-bb2a-df7e8ad840d9" />
The list mount working
<img width="1634" height="1702" alt="image" src="https://github.com/user-attachments/assets/9d9f4ca7-b173-4cb3-8cb9-e213acddd41b" />


Screenshot of /.gemin/.env
<img width="650" height="290" alt="image" src="https://github.com/user-attachments/assets/a8e68234-2765-443a-974b-ba7c116f8fd0" />
/mcp-list working
<img width="794" height="738" alt="image" src="https://github.com/user-attachments/assets/0b2adcf2-159f-458a-a42d-912fe8fe162c" />




## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] I have documented a clear reason for, and description of, the change I am making.

- [x] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.

If you have any questions, please contact your direct supervisor, GRC (#team-grc), or the PCI working group (#proj-pci-reboot). You can also find more information at [PCI Compliance](https://hashicorp.atlassian.net/wiki/spaces/SEC/pages/2784559202/PCI+Compliance).
